### PR TITLE
Renovate/icr.io appcafe open liberty sample fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -209,7 +209,7 @@ resource "kubernetes_namespace" "websphere_liberty_sampleapp_namespace" {
 
 locals {
   websphere_liberty_operator_sampleapp_image_path       = "icr.io/appcafe/open-liberty/samples/getting-started"
-  websphere_liberty_operator_sampleapp_image_tag_digest = "latest@sha256:d735c2ceae5945a0f20adcbcb04e55472d2520b6d1abb6d3049c8521234d3b7a" # datasource: icr.io/appcafe/open-liberty/samples/getting-started
+  websphere_liberty_operator_sampleapp_image_tag_digest = "latest@sha256:cd4a9cc586dc371c34df44853abd3301bfd9bfde14efa01170625342a070d14f" # datasource: icr.io/appcafe/open-liberty/samples/getting-started
 }
 
 resource "helm_release" "websphere_liberty_operator_sampleapp" {

--- a/tests/resources/main.tf
+++ b/tests/resources/main.tf
@@ -122,7 +122,7 @@ module "landing_zone" {
       "use_data": false
     }
   ],
-  "enable_transit_gateway": true,
+  "enable_transit_gateway": false,
   "f5_template_data": {
     "app_id": "null",
     "as3_declaration_url": "null",


### PR DESCRIPTION
### Description

Fixing this renovate PR https://github.com/terraform-ibm-modules/terraform-ibm-websphere-liberty-operator/pull/17

| Package | Update | Change |
|---|---|---|
| icr.io/appcafe/open-liberty/samples/getting-started | digest | `d735c2c` -> `cd4a9cc` |

Skipped upgrade test as the new sample app version shows different hash
Disabled contextually the creation of a transit gw that shouldn't be needed by the test

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Fixed test

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [x] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
