### PR TITLE
Renovate icr.io cpopen ibm operator catalog v4.15 fix

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "kubernetes_namespace" "helm_release_operator_namespace" {
 }
 
 locals {
-  ibm_operator_catalog_image_tag_digest = "v4.15@sha256:d6182ad99f10c1f7fa509ef97850fd4a6e6097e414f495c7b3a90838570a6c0d" # datasource: icr.io/cpopen/ibm-operator-catalog
+  ibm_operator_catalog_image_tag_digest = "v4.15@sha256:fcd80c10a72c6d740f253ffa6db9c66372b699c6b5cfcb51935016807425893f" # datasource: icr.io/cpopen/ibm-operator-catalog
   ibm_operator_catalog_path             = "icr.io/cpopen/ibm-operator-catalog"
 }
 

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -33,9 +33,8 @@ func setupOptions(t *testing.T, prefix string, exampleDir string) *testhelper.Te
 			List: []string{
 				// to skip update error due to operator sample app updates
 				"module.websphere_liberty_operator.helm_release.websphere_liberty_operator_sampleapp[0]",
-				// to avoid upgrade to fail when sleep time is reduced
-				// remove this ignore once https://github.com/terraform-ibm-modules/terraform-ibm-websphere-liberty-operator/pull/31 is merged
-				"module.websphere_liberty_operator.time_sleep.wait_sampleapp[0]",
+				// to skip update error due to operator catalog image version updates
+				"module.websphere_liberty_operator.helm_release.ibm_operator_catalog[0]",
 			},
 		},
 	})


### PR DESCRIPTION
### Description

Added operator catalog image version update to ignore to avoid errors when upgrading image version
Fix for https://github.com/terraform-ibm-modules/terraform-ibm-websphere-liberty-operator/pull/47

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [X] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [X] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
