### PR TITLE
Fix for the catalog pre-validation script

### DIFF
--- a/tests/resources/outputs.tf
+++ b/tests/resources/outputs.tf
@@ -12,11 +12,6 @@ output "region" {
   description = "Region where SLZ ROKS Cluster is deployed."
 }
 
-output "management_cluster_id" {
-  value       = module.landing_zone.management_cluster_id
-  description = "management cluster ID."
-}
-
 output "workload_cluster_id" {
   value       = module.landing_zone.workload_cluster_id
   description = "workload cluster ID."

--- a/tests/scripts/pre-validation-slz-roks.sh
+++ b/tests/scripts/pre-validation-slz-roks.sh
@@ -21,22 +21,35 @@ TF_VARS_FILE="terraform.tfvars"
   # $VALIDATION_APIKEY is available in the catalog runtime
   {
     echo "ibmcloud_api_key=\"${VALIDATION_APIKEY}\""
+    echo "prefix=\"was-slz-$(openssl rand -hex 2)\""
     echo "region=\"${REGION}\""
   } >> ${TF_VARS_FILE}
   terraform apply -input=false -auto-approve -var-file=${TF_VARS_FILE} || exit 1
 
   region_var_name="region"
   cluster_id_var_name="cluster_id"
-  cluster_id_value=$(terraform output -state=terraform.tfstate -raw management_cluster_id)
+  prefix_var_name="prefix"
+  prefix_var_value=$(terraform output -state=terraform.tfstate -raw prefix)
+
+  rg_var_name="resource_group"
+  rg_var_value="${prefix_var_value}-workload-rg"
+
+  echo "Appending '${prefix_var_name}', '${rg_var_name}' and '${region_var_name}' input variable values to ${JSON_FILE}.."
+
+  cluster_id_value=$(terraform output -state=terraform.tfstate -raw workload_cluster_id)
 
   echo "Appending '${cluster_id_var_name}' and '${region_var_name}' input variable values to ${JSON_FILE}.."
 
   cd "${cwd}"
-  jq -r --arg region_var_name "${region_var_name}" \
+  jq -r --arg prefix_var_name "${prefix_var_name}" \
+        --arg prefix_var_value "${prefix_var_value}" \
+        --arg rg_var_name "${rg_var_name}" \
+        --arg rg_var_value "${rg_var_value}" \
+        --arg region_var_name "${region_var_name}" \
         --arg region_var_value "${REGION}" \
         --arg cluster_id_var_name "${cluster_id_var_name}" \
         --arg cluster_id_value "${cluster_id_value}" \
-        '. + {($region_var_name): $region_var_value, ($cluster_id_var_name): $cluster_id_value}' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
+        '. + {($prefix_var_name): $prefix_var_value, ($cluster_id_var_name): $cluster_id_value}, ($rg_var_name): $rg_var_value, ($region_var_name): $region_var_value}' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
 
   echo "Pre-validation complete successfully"
 )

--- a/tests/scripts/pre-validation-slz-roks.sh
+++ b/tests/scripts/pre-validation-slz-roks.sh
@@ -34,11 +34,9 @@ TF_VARS_FILE="terraform.tfvars"
   rg_var_name="resource_group"
   rg_var_value="${prefix_var_value}-workload-rg"
 
-  echo "Appending '${prefix_var_name}', '${rg_var_name}' and '${region_var_name}' input variable values to ${JSON_FILE}.."
+  echo "Appending '${prefix_var_name}', '${rg_var_name}', '${cluster_id_var_name}' and '${region_var_name}' input variable values to ${JSON_FILE}.."
 
   cluster_id_value=$(terraform output -state=terraform.tfstate -raw workload_cluster_id)
-
-  echo "Appending '${cluster_id_var_name}' and '${region_var_name}' input variable values to ${JSON_FILE}.."
 
   cd "${cwd}"
   jq -r --arg prefix_var_name "${prefix_var_name}" \
@@ -49,7 +47,7 @@ TF_VARS_FILE="terraform.tfvars"
         --arg region_var_value "${REGION}" \
         --arg cluster_id_var_name "${cluster_id_var_name}" \
         --arg cluster_id_value "${cluster_id_value}" \
-        '. + {($prefix_var_name): $prefix_var_value, ($cluster_id_var_name): $cluster_id_value}, ($rg_var_name): $rg_var_value, ($region_var_name): $region_var_value}' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
+        '. + {($prefix_var_name): $prefix_var_value, ($cluster_id_var_name): $cluster_id_value, ($rg_var_name): $rg_var_value, ($region_var_name): $region_var_value}' "${JSON_FILE}" > tmpfile && mv tmpfile "${JSON_FILE}" || exit 1
 
   echo "Pre-validation complete successfully"
 )


### PR DESCRIPTION
### Description

Fixed catalog prevalidation script:
- added random prefix for test
- collected workload clusterID

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
