### PR TITLE
fix: Fixed workaround for default pool management in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ output "websphere_liberty_operator_sample_app_url" {
   description = "URL of the IBM WebSphere Liberty operator sample app if deployed."
   value       = local.websphere_liberty_operator_sampleapp_url
 }
-
 ```
 
 ### Required IAM access policies

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -35,11 +35,13 @@ func setupOptions(t *testing.T, prefix string, exampleDir string) *testhelper.Te
 				"module.websphere_liberty_operator.helm_release.websphere_liberty_operator_sampleapp[0]",
 				// to skip update error due to operator catalog image version updates
 				"module.websphere_liberty_operator.helm_release.ibm_operator_catalog[0]",
-				// workaround for the issue https://github.ibm.com/GoldenEye/issues/issues/10743
-				// when the issue is fixed on IKS, so the destruction of default workers pool is correctly managed on provider/clusters service the next two entries should be removed
-				"module.ocp_base.ibm_container_vpc_worker_pool.autoscaling_pool[\"default\"]",
-				"module.ocp_base.ibm_container_vpc_worker_pool.pool[\"default\"]",
 			},
+		},
+		ImplicitDestroy: []string{
+			// workaround for the issue https://github.ibm.com/GoldenEye/issues/issues/10743
+			// when the issue is fixed on IKS, so the destruction of default workers pool is correctly managed on provider/clusters service the next two entries should be removed
+			"module.ocp_base.ibm_container_vpc_worker_pool.autoscaling_pool[\"default\"]",
+			"module.ocp_base.ibm_container_vpc_worker_pool.pool[\"default\"]",
 		},
 	})
 	return options

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -35,10 +35,6 @@ func setupOptions(t *testing.T, prefix string, exampleDir string) *testhelper.Te
 				"module.websphere_liberty_operator.helm_release.websphere_liberty_operator_sampleapp[0]",
 				// to skip update error due to operator catalog image version updates
 				"module.websphere_liberty_operator.helm_release.ibm_operator_catalog[0]",
-				// workaround for the issue https://github.ibm.com/GoldenEye/issues/issues/10743
-				// when the issue is fixed on IKS, so the destruction of default workers pool is correctly managed on provider/clusters service the next two entries should be removed
-				"module.ocp_base.ibm_container_vpc_worker_pool.autoscaling_pool[\"default\"]",
-				"module.ocp_base.ibm_container_vpc_worker_pool.pool[\"default\"]",
 			},
 		},
 		ImplicitDestroy: []string{

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -35,6 +35,10 @@ func setupOptions(t *testing.T, prefix string, exampleDir string) *testhelper.Te
 				"module.websphere_liberty_operator.helm_release.websphere_liberty_operator_sampleapp[0]",
 				// to skip update error due to operator catalog image version updates
 				"module.websphere_liberty_operator.helm_release.ibm_operator_catalog[0]",
+				// workaround for the issue https://github.ibm.com/GoldenEye/issues/issues/10743
+				// when the issue is fixed on IKS, so the destruction of default workers pool is correctly managed on provider/clusters service the next two entries should be removed
+				"module.ocp_base.ibm_container_vpc_worker_pool.autoscaling_pool[\"default\"]",
+				"module.ocp_base.ibm_container_vpc_worker_pool.pool[\"default\"]",
 			},
 		},
 	})


### PR DESCRIPTION
### Description

fix: Fixed workaround for default pool management in tests

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

fix: Fixed workaround for default pool management in tests

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [x] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
